### PR TITLE
Add End trial related classes and flow

### DIFF
--- a/InteractExperiment.xcodeproj/project.pbxproj
+++ b/InteractExperiment.xcodeproj/project.pbxproj
@@ -15,6 +15,10 @@
 		8B5ACB882A2E0452002F5AA9 /* FileManagerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5ACB872A2E0452002F5AA9 /* FileManagerExtensions.swift */; };
 		8B6477F62A2674570071F582 /* CreateConfigurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6477F52A2674570071F582 /* CreateConfigurationView.swift */; };
 		8B6477F92A267FD60071F582 /* ColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6477F82A267FD60071F582 /* ColorExtensions.swift */; };
+		8B8DFEC02A52FEBF00D8CE5D /* EndExperimentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8DFEBF2A52FEBF00D8CE5D /* EndExperimentView.swift */; };
+		8B8DFEC22A52FED000D8CE5D /* EndExperimentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8DFEC12A52FED000D8CE5D /* EndExperimentViewModel.swift */; };
+		8B8DFEC42A52FEE700D8CE5D /* EndExperimentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8DFEC32A52FEE700D8CE5D /* EndExperimentCoordinator.swift */; };
+		8B8DFEC62A52FF0600D8CE5D /* EndExperimentFlowState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8DFEC52A52FF0600D8CE5D /* EndExperimentFlowState.swift */; };
 		8B905C332A49BA15006A9A53 /* CreateConfigurationFlowState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B905C322A49BA15006A9A53 /* CreateConfigurationFlowState.swift */; };
 		8B905C352A49CB68006A9A53 /* ExperimentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B905C342A49CB68006A9A53 /* ExperimentCoordinator.swift */; };
 		8B905C372A49CB6F006A9A53 /* ExperimentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B905C362A49CB6F006A9A53 /* ExperimentView.swift */; };
@@ -53,6 +57,10 @@
 		8B5ACB872A2E0452002F5AA9 /* FileManagerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerExtensions.swift; sourceTree = "<group>"; };
 		8B6477F52A2674570071F582 /* CreateConfigurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateConfigurationView.swift; sourceTree = "<group>"; };
 		8B6477F82A267FD60071F582 /* ColorExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtensions.swift; sourceTree = "<group>"; };
+		8B8DFEBF2A52FEBF00D8CE5D /* EndExperimentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndExperimentView.swift; sourceTree = "<group>"; };
+		8B8DFEC12A52FED000D8CE5D /* EndExperimentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndExperimentViewModel.swift; sourceTree = "<group>"; };
+		8B8DFEC32A52FEE700D8CE5D /* EndExperimentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndExperimentCoordinator.swift; sourceTree = "<group>"; };
+		8B8DFEC52A52FF0600D8CE5D /* EndExperimentFlowState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndExperimentFlowState.swift; sourceTree = "<group>"; };
 		8B905C322A49BA15006A9A53 /* CreateConfigurationFlowState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateConfigurationFlowState.swift; sourceTree = "<group>"; };
 		8B905C342A49CB68006A9A53 /* ExperimentCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExperimentCoordinator.swift; sourceTree = "<group>"; };
 		8B905C362A49CB6F006A9A53 /* ExperimentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExperimentView.swift; sourceTree = "<group>"; };
@@ -112,6 +120,17 @@
 				8B5ACB872A2E0452002F5AA9 /* FileManagerExtensions.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		8B8DFEBE2A52FEA600D8CE5D /* EndExperiment */ = {
+			isa = PBXGroup;
+			children = (
+				8B8DFEBF2A52FEBF00D8CE5D /* EndExperimentView.swift */,
+				8B8DFEC12A52FED000D8CE5D /* EndExperimentViewModel.swift */,
+				8B8DFEC32A52FEE700D8CE5D /* EndExperimentCoordinator.swift */,
+				8B8DFEC52A52FF0600D8CE5D /* EndExperimentFlowState.swift */,
+			);
+			path = EndExperiment;
 			sourceTree = "<group>";
 		};
 		8BADE42E2A2CA34A0087C74D /* CommonViews */ = {
@@ -203,6 +222,7 @@
 				8BE6C0F62A4C6AE000B3C8E2 /* StartExperimentFlowState.swift */,
 				8BE6C0F82A4C80AD00B3C8E2 /* Experiment */,
 				8BF7439A2A4B1D8200787997 /* Instruction */,
+				8B8DFEBE2A52FEA600D8CE5D /* EndExperiment */,
 				8BE16A302A4084D300A83B9E /* Views */,
 				8BE16A2F2A4084C700A83B9E /* Models */,
 			);
@@ -336,7 +356,9 @@
 				8B2E59D82A33679700726D6C /* ExperimentImageListView.swift in Sources */,
 				8B905C352A49CB68006A9A53 /* ExperimentCoordinator.swift in Sources */,
 				8BB3659E2A1F9F2400DE2B5C /* InteractExperimentApp.swift in Sources */,
+				8B8DFEC22A52FED000D8CE5D /* EndExperimentViewModel.swift in Sources */,
 				8BBB17FC2A48AF3600BB5E7B /* RootFlowState.swift in Sources */,
+				8B8DFEC02A52FEBF00D8CE5D /* EndExperimentView.swift in Sources */,
 				8B905C372A49CB6F006A9A53 /* ExperimentView.swift in Sources */,
 				8BADE4372A2D18F10087C74D /* ConfigurationModel.swift in Sources */,
 				8B19F4722A52099600433112 /* ExperimentFlowState.swift in Sources */,
@@ -344,8 +366,10 @@
 				8BADE4302A2CA3650087C74D /* ToastView.swift in Sources */,
 				8BE16A2E2A4083F500A83B9E /* ExperimentViewModel.swift in Sources */,
 				8BAF3C682A1FB28E00C0A4CE /* RootView.swift in Sources */,
+				8B8DFEC42A52FEE700D8CE5D /* EndExperimentCoordinator.swift in Sources */,
 				8B152A0E2A43191300D666AF /* CreateConfigurationCoordinator.swift in Sources */,
 				8BE16A322A4084F300A83B9E /* InteractLogModel.swift in Sources */,
+				8B8DFEC62A52FF0600D8CE5D /* EndExperimentFlowState.swift in Sources */,
 				8B95C01A2A27E5B60094C925 /* ImagePicker.swift in Sources */,
 				8B13B52D2A51CCEA004E98A8 /* InputDataModel.swift in Sources */,
 				8BF743A22A4B1DEC00787997 /* InstructionFlowState.swift in Sources */,

--- a/InteractExperiment/ExperimentProcess/EndExperiment/EndExperimentCoordinator.swift
+++ b/InteractExperiment/ExperimentProcess/EndExperiment/EndExperimentCoordinator.swift
@@ -1,0 +1,31 @@
+//
+//  EndExperimentCoordinator.swift
+//  InteractExperiment
+//
+//  Created by cabbage on 2023/7/3.
+//
+
+import SwiftUI
+
+struct EndExperimentCoordinator: View {
+    @StateObject var state: InstructionFlowState
+    
+    let configurations: ConfigurationModel
+    let experimentModel: InteractLogModel
+    
+    init(navigationPath: Binding<NavigationPath>, configurations: ConfigurationModel, experiment: InteractLogModel) {
+        _state = .init(wrappedValue: .init(path: navigationPath))
+        self.configurations = configurations
+        self.experimentModel = experiment
+    }
+    
+    var body: some View {
+        let viewModel = EndExperimentViewModel(configurations: configurations, experiment: experimentModel)
+        EndExperimentView(viewModel: viewModel)
+            .onClosed {
+                state.path.removeLast(state.path.count)
+            }
+            .toolbar(.hidden, for: .navigationBar)
+            
+    }
+}

--- a/InteractExperiment/ExperimentProcess/EndExperiment/EndExperimentFlowState.swift
+++ b/InteractExperiment/ExperimentProcess/EndExperiment/EndExperimentFlowState.swift
@@ -1,0 +1,17 @@
+//
+//  EndExperimentFlowState.swift
+//  InteractExperiment
+//
+//  Created by cabbage on 2023/7/3.
+//
+
+import SwiftUI
+
+class EndExperimentFlowState: ObservableObject {
+    @Binding var path: NavigationPath
+    
+    init(path: Binding<NavigationPath>) {
+        _path = .init(projectedValue: path)
+    }
+    
+}

--- a/InteractExperiment/ExperimentProcess/EndExperiment/EndExperimentView.swift
+++ b/InteractExperiment/ExperimentProcess/EndExperiment/EndExperimentView.swift
@@ -1,0 +1,40 @@
+//
+//  EndExperimentView.swift
+//  InteractExperiment
+//
+//  Created by cabbage on 2023/7/3.
+//
+
+import SwiftUI
+
+struct EndExperimentView: View {
+    let viewModel: EndExperimentViewModelProtocol
+    var closeClosure: () -> Void = { }
+    
+    var body: some View {
+        VStack {
+            Text("The experiment is finished, thanks for taking part.")
+                .font(.title)
+                .padding(26)
+            Button("close", action: closeClosure)
+                .padding(.init(top: 8, leading: 8, bottom: 8, trailing: 8))
+                .foregroundColor(.white)
+                .background(Color.blue)
+                .clipShape(RoundedRectangle(cornerSize: .init(width: 6, height: 6)))
+        }
+    }
+}
+
+extension EndExperimentView {
+    func onClosed(perform action: @escaping() -> Void) -> Self {
+        var copy = self
+        copy.closeClosure = action
+        return copy
+    }
+}
+
+struct EndExperimentView_Previews: PreviewProvider {
+    static var previews: some View {
+        EndExperimentView(viewModel: EndExperimentViewModel.mock)
+    }
+}

--- a/InteractExperiment/ExperimentProcess/EndExperiment/EndExperimentViewModel.swift
+++ b/InteractExperiment/ExperimentProcess/EndExperiment/EndExperimentViewModel.swift
@@ -1,0 +1,30 @@
+//
+//  EndExperimentViewModel.swift
+//  InteractExperiment
+//
+//  Created by cabbage on 2023/7/3.
+//
+
+import Foundation
+
+protocol EndExperimentViewModelProtocol {
+    var configurations: ConfigurationModel { get }
+    var experiment: InteractLogModel { get }
+}
+
+class EndExperimentViewModel: EndExperimentViewModelProtocol {
+    
+    private(set) var configurations: ConfigurationModel
+    private(set) var experiment: InteractLogModel
+    
+    init(configurations: ConfigurationModel, experiment: InteractLogModel) {
+        self.configurations = configurations
+        self.experiment = experiment
+    }
+}
+
+extension EndExperimentViewModel {
+    static var mock: EndExperimentViewModel {
+        EndExperimentViewModel(configurations: .mock, experiment: .mock)
+    }
+}

--- a/InteractExperiment/ExperimentProcess/Experiment/ExperimentCoordinator.swift
+++ b/InteractExperiment/ExperimentProcess/Experiment/ExperimentCoordinator.swift
@@ -26,9 +26,14 @@ struct ExperimentCoordinator: View {
                     let configurations = viewModel.configuration
                     let experiment = viewModel.experiment
                     state.path.append(ExperimentFlowLink.stimulus(configurations, experiment))
-                case .stimulus:
-                    //TODO: show end message
-                    break
+                case let .stimulus(index):
+                    let configurations = viewModel.configuration
+                    let experiment = viewModel.experiment
+                    if index == 0 {
+                        state.path.append(ExperimentFlowLink.stimulus(configurations, experiment))
+                    } else if index == configurations.stimulusImages.count {
+                        state.path.append(ExperimentFlowLink.endTrial(configurations, experiment))
+                    }
                 default:
                     break
                 }

--- a/InteractExperiment/ExperimentProcess/StartExperimentFlowState.swift
+++ b/InteractExperiment/ExperimentProcess/StartExperimentFlowState.swift
@@ -10,6 +10,7 @@ import SwiftUI
 enum ExperimentFlowLink: Hashable, Identifiable {
     case familiarisation(ConfigurationModel, InteractLogModel)
     case stimulus(ConfigurationModel, InteractLogModel)
+    case endTrial(ConfigurationModel, InteractLogModel)
     
     var id: String { String(describing: self) }
 }

--- a/InteractExperiment/RootView/RootCoordinator.swift
+++ b/InteractExperiment/RootView/RootCoordinator.swift
@@ -54,8 +54,11 @@ private extension RootCoordinator {
         case let .familiarisation(configurations, experiment),
             let .stimulus(configurations, experiment):
             ExperimentCoordinator(navigationPath: $state.path, configurations: configurations, experiment: experiment)
-        default:
-            Text("not implemented process")
+        case let .endTrial(configurations, experiment):
+            EndExperimentCoordinator(navigationPath: $state.path, configurations: configurations, experiment: experiment)
+                .onDisappear {
+                    columnVisibility = .automatic
+                }
         }
     }
     


### PR DESCRIPTION
![Simulator Screen Recording - iPad (10th generation) - 2023-07-02 at 21 09 27](https://github.com/musicabbage/interaction-experiment/assets/8994570/4e70a924-560b-4047-80bb-57da4fe294f5)

- Add EndExperiment-related classes: View, ViewModel, Coordinator, and FlowState
- Check the index value in ExperimentCoordinator when the state is `stimulus`.
   - `index == 0` : Push ExperimentView for Stimulus process
   - `index == StimulusImage.count` : All of the stimulus images are shown. Push EndExperimentView