### PR TITLE
Refactor columnVisibility update timing

### DIFF
--- a/InteractExperiment/ExperimentProcess/StartExperimentCoordinator.swift
+++ b/InteractExperiment/ExperimentProcess/StartExperimentCoordinator.swift
@@ -12,8 +12,8 @@ struct StartExperimentCoordinator: View {
     
     private let configurations: ConfigurationModel
     
-    init(navigationPath: Binding<NavigationPath>, columnVisibility: Binding<NavigationSplitViewVisibility>, configurations: ConfigurationModel) {
-        _state = .init(wrappedValue: .init(path: navigationPath, columnVisibility: columnVisibility))
+    init(navigationPath: Binding<NavigationPath>, configurations: ConfigurationModel) {
+        _state = .init(wrappedValue: .init(path: navigationPath))
         self.configurations = configurations
     }
     
@@ -24,7 +24,6 @@ struct StartExperimentCoordinator: View {
         .toolbar(.hidden, for: .navigationBar)
         .onAppear {
             state.showParticipantId = true
-            state.columnVisibility = .detailOnly
         }
         .alert("Participant ID", isPresented: $state.showParticipantId, actions: alertView)
     }

--- a/InteractExperiment/ExperimentProcess/StartExperimentFlowState.swift
+++ b/InteractExperiment/ExperimentProcess/StartExperimentFlowState.swift
@@ -17,15 +17,13 @@ enum ExperimentFlowLink: Hashable, Identifiable {
 
 class StartExperimentFlowState: ObservableObject {
     @Binding var path: NavigationPath
-    @Binding var columnVisibility: NavigationSplitViewVisibility
     @Published var showParticipantId: Bool = false
     
-    init(path: Binding<NavigationPath>, columnVisibility: Binding<NavigationSplitViewVisibility>) {
+    init(path: Binding<NavigationPath>) {
         _path = .init(projectedValue: path)
-        _columnVisibility = .init(projectedValue: columnVisibility)
     }
     
     static var mock: StartExperimentFlowState {
-        .init(path: .constant(.init()), columnVisibility: .constant(.automatic))
+        .init(path: .constant(.init()))
     }
 }

--- a/InteractExperiment/RootView/RootCoordinator.swift
+++ b/InteractExperiment/RootView/RootCoordinator.swift
@@ -24,7 +24,6 @@ struct RootCoordinator: View {
                     .sheet(item: $state.presentedItem, content: presentContent)
                     .fullScreenCover(item: $state.coverItem, content: coverContent)
             }
-            
         }
     }
 }
@@ -36,7 +35,10 @@ private extension RootCoordinator {
         case let .configCreated(configPath):
             if let data = try? Data(contentsOf: URL(filePath: configPath)),
                let configurations = try? JSONDecoder().decode(ConfigurationModel.self, from: data) {
-                StartExperimentCoordinator(navigationPath: $state.path, columnVisibility: $columnVisibility, configurations: configurations)
+                StartExperimentCoordinator(navigationPath: $state.path, configurations: configurations)
+                    .onAppear {
+                        columnVisibility = .detailOnly
+                    }
             } else {
                 Text("instruction get config error")
             }


### PR DESCRIPTION
Change `columnVisibility` state in RootCoordinator instead of putting it in the child coordinators