### PR TITLE
fix(#24): add ExperimentGestureView to handle swipe gestures

### DIFF
--- a/InteractExperiment.xcodeproj/project.pbxproj
+++ b/InteractExperiment.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		8B2E59D82A33679700726D6C /* ExperimentImageListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2E59D72A33679700726D6C /* ExperimentImageListView.swift */; };
 		8B5ACB882A2E0452002F5AA9 /* FileManagerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5ACB872A2E0452002F5AA9 /* FileManagerExtensions.swift */; };
 		8B604D112A587AF200E1AEE7 /* PreviousExperimentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B604D102A587AF200E1AEE7 /* PreviousExperimentsView.swift */; };
+		8B62488E2A5CB5F4007C52F2 /* ExperimentGestureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B62488D2A5CB5F4007C52F2 /* ExperimentGestureView.swift */; };
 		8B6477F62A2674570071F582 /* CreateConfigurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6477F52A2674570071F582 /* CreateConfigurationView.swift */; };
 		8B6477F92A267FD60071F582 /* ColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6477F82A267FD60071F582 /* ColorExtensions.swift */; };
 		8B8DFEC02A52FEBF00D8CE5D /* EndExperimentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8DFEBF2A52FEBF00D8CE5D /* EndExperimentView.swift */; };
@@ -63,6 +64,7 @@
 		8B2E59D72A33679700726D6C /* ExperimentImageListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentImageListView.swift; sourceTree = "<group>"; };
 		8B5ACB872A2E0452002F5AA9 /* FileManagerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerExtensions.swift; sourceTree = "<group>"; };
 		8B604D102A587AF200E1AEE7 /* PreviousExperimentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviousExperimentsView.swift; sourceTree = "<group>"; };
+		8B62488D2A5CB5F4007C52F2 /* ExperimentGestureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentGestureView.swift; sourceTree = "<group>"; };
 		8B6477F52A2674570071F582 /* CreateConfigurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateConfigurationView.swift; sourceTree = "<group>"; };
 		8B6477F82A267FD60071F582 /* ColorExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtensions.swift; sourceTree = "<group>"; };
 		8B8DFEBF2A52FEBF00D8CE5D /* EndExperimentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndExperimentView.swift; sourceTree = "<group>"; };
@@ -129,6 +131,7 @@
 			isa = PBXGroup;
 			children = (
 				8B17FF432A5ADFE800DF3B69 /* PreviousExperimentItemView.swift */,
+				8B62488D2A5CB5F4007C52F2 /* ExperimentGestureView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -415,6 +418,7 @@
 				8BA49F672A5979AB00148687 /* PreviousExperimentsModel.swift in Sources */,
 				8B152A0E2A43191300D666AF /* CreateConfigurationCoordinator.swift in Sources */,
 				8BA49F692A59857600148687 /* ViewStyleExtensions.swift in Sources */,
+				8B62488E2A5CB5F4007C52F2 /* ExperimentGestureView.swift in Sources */,
 				8BE16A322A4084F300A83B9E /* InteractLogModel.swift in Sources */,
 				8B8DFEC62A52FF0600D8CE5D /* EndExperimentFlowState.swift in Sources */,
 				8B95C01A2A27E5B60094C925 /* ImagePicker.swift in Sources */,

--- a/InteractExperiment/ExperimentProcess/Models/InteractLogModel.swift
+++ b/InteractExperiment/ExperimentProcess/Models/InteractLogModel.swift
@@ -18,6 +18,7 @@ struct InteractLogModel: Codable, Identifiable, Hashable {
     let configId: String
     var familiarisationInput: [InputDataModel] = []
     var stimulusInput: [InputDataModel] = []
+    var stimulusIndex: Int = 0
     
     var state: State {
         //TODO: check return state
@@ -26,7 +27,7 @@ struct InteractLogModel: Codable, Identifiable, Hashable {
         } else if familiarisationInput.isEmpty {
             return .familiarisation
         } else {
-            return .stimulus(stimulusInput.count)
+            return .stimulus(stimulusIndex)
         }
     }
     
@@ -38,10 +39,12 @@ struct InteractLogModel: Codable, Identifiable, Hashable {
     
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.familiarisationInput = try container.decode([InputDataModel].self, forKey: .familiarisationInput)
         self.participantId = try container.decode(String.self, forKey: .participantId)
         self.id = try container.decode(String.self, forKey: .id)
         self.configId = try container.decode(String.self, forKey: .configId)
+        self.familiarisationInput = try container.decode([InputDataModel].self, forKey: .familiarisationInput)
+        self.stimulusInput = try container.decode([InputDataModel].self, forKey: .stimulusInput)
+        self.stimulusIndex = try container.decode(Int.self, forKey: .stimulusIndex)
     }
     
     static func == (lhs: InteractLogModel, rhs: InteractLogModel) -> Bool {

--- a/InteractExperiment/ExperimentProcess/Views/InputPane.swift
+++ b/InteractExperiment/ExperimentProcess/Views/InputPane.swift
@@ -15,11 +15,11 @@ struct Line {
 struct InputPane: View {
     
     @Binding private var lines: [Line]
-    @State private var selectedColor = Color.black
+    @Binding private var selectedColour: Color
     
-    init(lines: Binding<[Line]>, selectedColor: SwiftUI.Color = Color.black) {
+    init(lines: Binding<[Line]>, selectedColour: Binding<Color>) {
         _lines = .init(projectedValue: lines)
-        self.selectedColor = selectedColor
+        _selectedColour = .init(projectedValue: selectedColour)
     }
     
     var body: some View {
@@ -48,7 +48,7 @@ struct InputPane: View {
                         let position = value.location
                         
                         if value.translation == .zero {
-                            lines.append(Line(points: [position], color: selectedColor))
+                            lines.append(Line(points: [position], color: selectedColour))
                         } else {
                             guard let lastIdx = lines.indices.last else {
                                 return
@@ -64,7 +64,7 @@ struct InputPane: View {
     @ViewBuilder
     func colorButton(color: Color) -> some View {
         Button {
-            selectedColor = color
+            selectedColour = color
         } label: {
             Image(systemName: "circle.fill")
                 .font(.largeTitle)
@@ -90,7 +90,7 @@ struct InputPane: View {
 
 struct InputPane_Previews: PreviewProvider {
     static var previews: some View {
-        InputPane(lines: .constant([]))
+        InputPane(lines: .constant([]), selectedColour: .constant(.blue))
     }
 }
 

--- a/InteractExperiment/PreviousExperiments/Views/ExperimentGestureView.swift
+++ b/InteractExperiment/PreviousExperiments/Views/ExperimentGestureView.swift
@@ -1,0 +1,105 @@
+//
+//  ExperimentGestureView.swift
+//  InteractExperiment
+//
+//  Created by cabbage on 2023/7/10.
+//
+
+import UIKit
+import SwiftUI
+
+struct ExperimentGestureView: UIViewRepresentable {
+    
+    private var dragClosure: (GestureView.State, CGPoint) -> Void = { _, _ in }
+    private var twoFingersSwipeClosure: (GestureView.SwipeDirection) -> Void = { _ in }
+    
+    func makeUIView(context: Context) -> GestureView {
+        let gestureView = GestureView()
+        gestureView.panClosure = dragClosure
+        gestureView.swipeClosure = twoFingersSwipeClosure
+        return gestureView
+    }
+    
+    func updateUIView(_ gestureView: GestureView, context: Context) {
+        gestureView.panClosure = dragClosure
+        gestureView.swipeClosure = twoFingersSwipeClosure
+    }
+    
+    func onDrag(perform action: @escaping(GestureView.State, CGPoint) -> Void) -> Self {
+        var copy = self
+        copy.dragClosure = action
+        return copy
+    }
+    
+    func onTwoFingersSwipe(perform action: @escaping(GestureView.SwipeDirection) -> Void) -> Self {
+        var copy = self
+        copy.twoFingersSwipeClosure = action
+        return copy
+    }
+}
+
+class GestureView: UIView {
+    enum State {
+        case began, update, end
+    }
+    
+    enum SwipeDirection {
+        case up, left, right
+    }
+    
+    var panClosure: (State, CGPoint) -> Void = { _, _ in }
+    var swipeClosure: (SwipeDirection) -> Void = { _ in }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+        
+        let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture(_:)))
+        panGesture.maximumNumberOfTouches = 1
+        addGestureRecognizer(panGesture)
+        
+        addGestureRecognizer(createSwipeGesture(direction: .up))
+        addGestureRecognizer(createSwipeGesture(direction: .right))
+        addGestureRecognizer(createSwipeGesture(direction: .left))
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension GestureView {
+    @objc func handleSwipeGesture(_ gesture: UISwipeGestureRecognizer) {
+        switch gesture.direction {
+        case .up:
+            swipeClosure(.up)
+        case .right:
+            swipeClosure(.right)
+        case .left:
+            swipeClosure(.left)
+        default:
+            break
+        }
+    }
+    
+    @objc func handlePanGesture(_ gesture: UIPanGestureRecognizer) {
+        let translation = gesture.location(in: self)
+        switch gesture.state {
+        case .began:
+            panClosure(.began, translation)
+        case .cancelled:
+            panClosure(.end, translation)
+        case .changed:
+            panClosure(.update, translation)
+        default:
+            break
+        }
+    }
+    
+    func createSwipeGesture(direction: UISwipeGestureRecognizer.Direction) -> UISwipeGestureRecognizer {
+        let gesture = UISwipeGestureRecognizer(target: self, action: #selector(handleSwipeGesture(_:)))
+        gesture.numberOfTouchesRequired = 2
+        gesture.direction = direction
+        return gesture
+    }
+}


### PR DESCRIPTION
- Add `ExperimentGestureView` for handling complex gestures. Currently support:
    - Drag gesture: for drawing
    - Swipe with 2 fingers: to show stimulus. Swipe up, right and left to show current, previous and next stimulus, respectively.

- With a drag gesture, pass the drag points to `InputPane` to show strokes.
- With swipe gestures, call viewmodel to show stimulus.

Swipe up
<img src="https://github.com/musicabbage/interaction-experiment/assets/8994570/956c87b3-61df-4fec-8039-bdc7616f9770" width="300" >

Swipe right
<img src="https://github.com/musicabbage/interaction-experiment/assets/8994570/dc69a8d4-898a-4a95-bae3-612c08afcb39" width="300" >

Swipe left
<img src="https://github.com/musicabbage/interaction-experiment/assets/8994570/5b0de53c-21e3-4526-af7b-8b490245f23a" width="300" >
